### PR TITLE
Add hints and qualified labels to LOC modules

### DIFF
--- a/lib/authoritex.ex
+++ b/lib/authoritex.ex
@@ -1,10 +1,16 @@
 defmodule Authoritex do
-  @type result :: %{id: String.t(), label: String.t()}
+  @type fetch_result :: %{
+          id: String.t(),
+          label: String.t() | nil,
+          qualified_label: String.t() | nil,
+          hint: String.t() | nil
+        }
+  @type search_result :: %{id: String.t(), label: String.t(), hint: String.t() | nil}
   @callback can_resolve?(String.t()) :: true | false
   @callback code() :: String.t()
   @callback description :: String.t()
-  @callback fetch(String.t()) :: {:ok, String.t() | nil} | {:error, term()}
-  @callback search(String.t(), integer()) :: {:ok, list(:result)} | {:error, term()}
+  @callback fetch(String.t()) :: {:ok, :fetch_result} | {:error, term()}
+  @callback search(String.t(), integer()) :: {:ok, list(:search_result)} | {:error, term()}
 
   @doc """
   Returns a label given an id.

--- a/lib/authoritex/loc/base.ex
+++ b/lib/authoritex/loc/base.ex
@@ -78,8 +78,12 @@ defmodule Authoritex.LOC.Base do
 
             rdf ->
               {:ok,
-               SweetXml.xpath(rdf, ~x"//madsrdf:authoritativeLabel", label: ~x"./text()"s)
-               |> Map.get(:label)}
+               SweetXml.xpath(rdf, ~x"./madsrdf:*",
+                 id: ~x"./@rdf:about"s,
+                 label: ~x"./madsrdf:authoritativeLabel[1]/text()"s,
+                 qualified_label: ~x"./madsrdf:authoritativeLabel[1]/text()"s,
+                 hint: ~x"./no_hint/text()"
+               )}
           end
         end
       rescue
@@ -104,7 +108,11 @@ defmodule Authoritex.LOC.Base do
 
             feed ->
               {:ok,
-               SweetXml.xpath(feed, ~x"//entry"l, id: ~x"./id/text()"s, label: ~x"./title/text()"s)}
+               SweetXml.xpath(feed, ~x"//entry"l,
+                 id: ~x{./link[@rel="alternate"][not(@type)]/@href}s,
+                 label: ~x"./title/text()"s,
+                 hint: ~x"./no_hint/text()"
+               )}
           end
         end
       rescue

--- a/test/authoritex/loc/languages_test.exs
+++ b/test/authoritex/loc/languages_test.exs
@@ -9,8 +9,10 @@ defmodule Authoritex.LOC.LanguagesTest do
     ],
     bad_uri: "http://id.loc.gov/vocabulary/languages/wrong-id",
     expected: [
-      id: "info:lc/vocabulary/languages/ang",
-      label: "English, Old (ca. 450-1100)"
+      id: "http://id.loc.gov/vocabulary/languages/ang",
+      label: "English, Old (ca. 450-1100)",
+      qualified_label: "English, Old (ca. 450-1100)",
+      hint: nil
     ],
     search_result_term: "english",
     search_count_term: ""

--- a/test/authoritex/loc/names_test.exs
+++ b/test/authoritex/loc/names_test.exs
@@ -9,8 +9,10 @@ defmodule Authoritex.LOC.NamesTest do
     ],
     bad_uri: "http://id.loc.gov/authorities/names/wrong-id",
     expected: [
-      id: "info:lc/authorities/names/no2011087251",
-      label: "Valim, Jose"
+      id: "http://id.loc.gov/authorities/names/no2011087251",
+      label: "Valim, Jose",
+      qualified_label: "Valim, Jose",
+      hint: nil
     ],
     search_result_term: "valim",
     search_count_term: "smith"

--- a/test/authoritex/loc/subject_headings_test.exs
+++ b/test/authoritex/loc/subject_headings_test.exs
@@ -9,8 +9,10 @@ defmodule Authoritex.LOC.SubjectHeadingsTest do
     ],
     bad_uri: "http://id.loc.gov/authorities/subjects/wrong-id",
     expected: [
-      id: "info:lc/authorities/subjects/sh85009792",
-      label: "Authority files (Information retrieval)"
+      id: "http://id.loc.gov/authorities/subjects/sh85009792",
+      label: "Authority files (Information retrieval)",
+      qualified_label: "Authority files (Information retrieval)",
+      hint: nil
     ],
     search_result_term: "authority",
     search_count_term: "authority"

--- a/test/authoritex/loc_test.exs
+++ b/test/authoritex/loc_test.exs
@@ -11,8 +11,10 @@ defmodule Authoritex.LOCTest do
     ],
     bad_uri: "http://id.loc.gov/vocabulary/organizations/wrong-id",
     expected: [
-      id: "info:lc/vocabulary/organizations/iehs",
-      label: "Evanston Township High School"
+      id: "http://id.loc.gov/vocabulary/organizations/iehs",
+      label: "Evanston Township High School",
+      qualified_label: "Evanston Township High School",
+      hint: nil
     ],
     search_result_term: "evanston township high",
     search_count_term: "high school"

--- a/test/authoritex_test.exs
+++ b/test/authoritex_test.exs
@@ -18,11 +18,17 @@ defmodule AuthoritexTest do
   describe "fetch/1" do
     test "success" do
       use_cassette "authoritex_fetch_success" do
-        assert Authoritex.fetch("http://id.loc.gov/authorities/names/no2011087251") ==
-                 {:ok, "Valim, Jose"}
+        expected = %{
+          hint: nil,
+          id: "http://id.loc.gov/authorities/names/no2011087251",
+          label: "Valim, Jose",
+          qualified_label: "Valim, Jose"
+        }
 
-        assert Authoritex.fetch("info:lc/authorities/names/no2011087251") ==
-                 {:ok, "Valim, Jose"}
+        assert Authoritex.fetch("http://id.loc.gov/authorities/names/no2011087251") ==
+                 {:ok, expected}
+
+        assert Authoritex.fetch("info:lc/authorities/names/no2011087251") == {:ok, expected}
       end
     end
 
@@ -52,8 +58,9 @@ defmodule AuthoritexTest do
 
         with {:ok, results} <- Authoritex.search("lcnaf", "valim") do
           assert Enum.member?(results, %{
-                   id: "info:lc/authorities/names/no2011087251",
-                   label: "Valim, Jose"
+                   id: "http://id.loc.gov/authorities/names/no2011087251",
+                   label: "Valim, Jose",
+                   hint: nil
                  })
         end
       end

--- a/test/support/authoritex_case.ex
+++ b/test/support/authoritex_case.ex
@@ -12,6 +12,8 @@ defmodule Authoritex.TestCase do
             bad_uri: use_opts[:bad_uri],
             expected_id: get_in(use_opts, [:expected, :id]),
             expected_label: get_in(use_opts, [:expected, :label]),
+            expected_qualified_label: get_in(use_opts, [:expected, :qualified_label]),
+            expected_hint: get_in(use_opts, [:expected, :hint]),
             search_result_term: use_opts[:search_result_term],
             search_count_term: use_opts[:search_count_term]
           ] do
@@ -40,7 +42,14 @@ defmodule Authoritex.TestCase do
           use_cassette "#{unquote(code)}_fetch_success" do
             unquote(test_uris)
             |> Enum.each(fn uri ->
-              assert unquote(module).fetch(uri) == {:ok, unquote(expected_label)}
+              assert unquote(module).fetch(uri) ==
+                       {:ok,
+                        %{
+                          id: unquote(expected_id),
+                          label: unquote(expected_label),
+                          qualified_label: unquote(expected_qualified_label),
+                          hint: unquote(expected_hint)
+                        }}
             end)
           end
         end
@@ -66,7 +75,8 @@ defmodule Authoritex.TestCase do
             with {:ok, results} <- unquote(module).search(unquote(search_result_term)) do
               assert Enum.member?(results, %{
                        id: unquote(expected_id),
-                       label: unquote(expected_label)
+                       label: unquote(expected_label),
+                       hint: unquote(expected_hint)
                      })
             end
           end


### PR DESCRIPTION
LOC hints are always nil, because there are no good qualifiers to pull. I would have liked to include the Scheme name for the “all LOC” search results, but the atom feed doesn't provide a good way to do that – we'd have to iterate over the results and fetch each one based on the ID stem.