### PR TITLE
Exclude .DS_Store files from hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -69,7 +69,8 @@ defmodule Authoritex.MixProject do
       files: ["lib", "mix.exs", "README.md", "LICENSE.md"],
       maintainers: ["Brendan Quinn", "Karen Shaw", "Michael B. Klein"],
       licenses: ["MIT"],
-      links: %{GitHub: @url}
+      links: %{GitHub: @url},
+      exclude_patterns: [".DS_Store"]
     ]
   end
 end


### PR DESCRIPTION
We don't want .DS_Store files in our hex package. See docs for reference at https://hexdocs.pm/hex/Mix.Tasks.Hex.Build.html#module-package-configuration