### PR TITLE
Fix issues in the test suite

### DIFF
--- a/test/authoritex/getty/ulan_test.exs
+++ b/test/authoritex/getty/ulan_test.exs
@@ -19,14 +19,16 @@ defmodule Authoritex.Getty.ULANTest do
     search_result_term: "palmer",
     search_count_term: "palmer"
 
-  describe "compound word search" do
-    with {:ok, results} <- ULAN.search("potter palmer") do
-      assert results
-             |> Enum.member?(%{
-               id: "http://vocab.getty.edu/ulan/500447664",
-               label: "Palmer, Potter",
-               hint: "American businessman, 1826-1902"
-             })
+  describe "ULAN-specific" do
+    test "compound word search" do
+      with {:ok, results} <- ULAN.search("potter palmer") do
+        assert results
+               |> Enum.member?(%{
+                 id: "http://vocab.getty.edu/ulan/500447664",
+                 label: "Palmer, Potter",
+                 hint: "American businessman, 1826-1902"
+               })
+      end
     end
   end
 end

--- a/test/authoritex/getty_test.exs
+++ b/test/authoritex/getty_test.exs
@@ -18,32 +18,34 @@ defmodule Authoritex.GettyTest do
 
   describe "delegate" do
     test "fetch authority-specific URIs" do
-      assert Getty.fetch("http://vocab.getty.edu/aat/300265149") ==
-               {:ok,
-                %{
-                  id: "http://vocab.getty.edu/aat/300265149",
-                  label: "dollars (paper money)",
-                  qualified_label: "dollars (paper money)",
-                  hint: nil
-                }}
+      use_cassette "getty_delegate_subauthorities", match_requests_on: [:query] do
+        assert Getty.fetch("http://vocab.getty.edu/aat/300265149") ==
+                 {:ok,
+                  %{
+                    id: "http://vocab.getty.edu/aat/300265149",
+                    label: "dollars (paper money)",
+                    qualified_label: "dollars (paper money)",
+                    hint: nil
+                  }}
 
-      assert Getty.fetch("http://vocab.getty.edu/tgn/2236134") ==
-               {:ok,
-                %{
-                  id: "http://vocab.getty.edu/tgn/2236134",
-                  label: "Chicago River",
-                  qualified_label: "Chicago River (Cook, Illinois, United States)",
-                  hint: "Cook, Illinois, United States"
-                }}
+        assert Getty.fetch("http://vocab.getty.edu/tgn/2236134") ==
+                 {:ok,
+                  %{
+                    id: "http://vocab.getty.edu/tgn/2236134",
+                    label: "Chicago River",
+                    qualified_label: "Chicago River (Cook, Illinois, United States)",
+                    hint: "Cook, Illinois, United States"
+                  }}
 
-      assert Getty.fetch("http://vocab.getty.edu/ulan/500447664") ==
-               {:ok,
-                %{
-                  id: "http://vocab.getty.edu/ulan/500447664",
-                  label: "Palmer, Potter",
-                  qualified_label: "Palmer, Potter (American businessman, 1826-1902)",
-                  hint: "American businessman, 1826-1902"
-                }}
+        assert Getty.fetch("http://vocab.getty.edu/ulan/500447664") ==
+                 {:ok,
+                  %{
+                    id: "http://vocab.getty.edu/ulan/500447664",
+                    label: "Palmer, Potter",
+                    qualified_label: "Palmer, Potter (American businessman, 1826-1902)",
+                    hint: "American businessman, 1826-1902"
+                  }}
+      end
     end
 
     test "gracefully fail to fetch a non-Getty URI" do

--- a/test/authoritex_test.exs
+++ b/test/authoritex_test.exs
@@ -17,7 +17,7 @@ defmodule AuthoritexTest do
 
   describe "fetch/1" do
     test "success" do
-      use_cassette "authoritex_fetch_success" do
+      use_cassette "authoritex_fetch_success", match_requests_on: [:query] do
         expected = %{
           hint: nil,
           id: "http://id.loc.gov/authorities/names/no2011087251",
@@ -33,7 +33,7 @@ defmodule AuthoritexTest do
     end
 
     test "failure" do
-      use_cassette "authoritex_fetch_failure" do
+      use_cassette "authoritex_fetch_failure", match_requests_on: [:query] do
         assert Authoritex.fetch("http://id.loc.gov/authorities/names/wrong-id") ==
                  {:error, 404}
       end
@@ -67,7 +67,7 @@ defmodule AuthoritexTest do
     end
 
     test "no results" do
-      use_cassette "authoritex_search_results_empty" do
+      use_cassette "authoritex_search_results_empty", match_requests_on: [:query] do
         assert {:ok, []} = Authoritex.search("lcnaf", "NO_resulteeeees")
       end
     end

--- a/test/fixtures/vcr_cassettes/getty_delegate_subauthorities.json
+++ b/test/fixtures/vcr_cassettes/getty_delegate_subauthorities.json
@@ -1,0 +1,89 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Accept": "application/sparql-results+xml;charset=UTF-8",
+        "User-Agent": "Authoritex"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://vocab.getty.edu/sparql.xml?query=SELECT+DISTINCT+%3Fs+%3Fname+%7B+BIND%28%3Chttp%3A%2F%2Fvocab.getty.edu%2Faat%2F300265149%3E+as+%3Fs%29+%3Fs+a+skos%3AConcept+%3B+gvp%3AprefLabelGVP+%5Bskosxl%3AliteralForm+%3Fname%5D+%3B+%7D+LIMIT+1"
+    },
+    "response": {
+      "binary": false,
+      "body": "<?xml version='1.0' encoding='UTF-8'?>\n<sparql xmlns='http://www.w3.org/2005/sparql-results#'>\n\t<head>\n\t\t<variable name='s'/>\n\t\t<variable name='name'/>\n\t</head>\n\t<results>\n\t\t<result>\n\t\t\t<binding name='s'>\n\t\t\t\t<uri>http://vocab.getty.edu/aat/300265149</uri>\n\t\t\t</binding>\n\t\t\t<binding name='name'>\n\t\t\t\t<literal xml:lang='en'>dollars (paper money)</literal>\n\t\t\t</binding>\n\t\t</result>\n\t</results>\n</sparql>\n",
+      "headers": {
+        "Access-Control-Allow-Origin": "*",
+        "Server": "GraphDB 6.2.7+sha.ab94d232, Forest 2.1.3, Sesame 2.7.8",
+        "Link": "<http://opendatacommons.org/licenses/by/1.0/>; rel=\"license\"",
+        "Content-Disposition": "attachment; filename=\"sparql.xml\"",
+        "Content-Type": "application/sparql-results+xml;charset=UTF-8",
+        "Content-Language": "en-US",
+        "Transfer-Encoding": "chunked",
+        "Date": "Wed, 27 May 2020 22:47:59 GMT"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Accept": "application/sparql-results+xml;charset=UTF-8",
+        "User-Agent": "Authoritex"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://vocab.getty.edu/sparql.xml?query=SELECT+DISTINCT+%3Fs+%3Fname+%3Fhint+%7B+BIND%28%3Chttp%3A%2F%2Fvocab.getty.edu%2Ftgn%2F2236134%3E+as+%3Fs%29+%3Fs+a+skos%3AConcept+%3B+gvp%3AprefLabelGVP+%5Bskosxl%3AliteralForm+%3Fname%5D+%3B+gvp%3AparentString+%3Fhint+.+%7D+LIMIT+1"
+    },
+    "response": {
+      "binary": false,
+      "body": "<?xml version='1.0' encoding='UTF-8'?>\n<sparql xmlns='http://www.w3.org/2005/sparql-results#'>\n\t<head>\n\t\t<variable name='s'/>\n\t\t<variable name='name'/>\n\t\t<variable name='hint'/>\n\t</head>\n\t<results>\n\t\t<result>\n\t\t\t<binding name='s'>\n\t\t\t\t<uri>http://vocab.getty.edu/tgn/2236134</uri>\n\t\t\t</binding>\n\t\t\t<binding name='name'>\n\t\t\t\t<literal>Chicago River</literal>\n\t\t\t</binding>\n\t\t\t<binding name='hint'>\n\t\t\t\t<literal>Cook, Illinois, United States, North and Central America, World</literal>\n\t\t\t</binding>\n\t\t</result>\n\t</results>\n</sparql>\n",
+      "headers": {
+        "Access-Control-Allow-Origin": "*",
+        "Server": "GraphDB 6.2.7+sha.ab94d232, Forest 2.1.3, Sesame 2.7.8",
+        "Link": "<http://opendatacommons.org/licenses/by/1.0/>; rel=\"license\"",
+        "Content-Disposition": "attachment; filename=\"sparql.xml\"",
+        "Content-Type": "application/sparql-results+xml;charset=UTF-8",
+        "Content-Language": "en-US",
+        "Transfer-Encoding": "chunked",
+        "Date": "Wed, 27 May 2020 22:47:59 GMT"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Accept": "application/sparql-results+xml;charset=UTF-8",
+        "User-Agent": "Authoritex"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://vocab.getty.edu/sparql.xml?query=SELECT+DISTINCT+%3Fs+%3Fname+%3Fhint+%7B+BIND%28%3Chttp%3A%2F%2Fvocab.getty.edu%2Fulan%2F500447664%3E+as+%3Fs%29+%3Fs+a+skos%3AConcept+%3B+gvp%3AprefLabelGVP+%5Bskosxl%3AliteralForm+%3Fname%5D+%3B+foaf%3Afocus%2Fgvp%3AbiographyPreferred+%5Bschema%3Adescription+%3Fhint%5D+%3B+%7D+LIMIT+1"
+    },
+    "response": {
+      "binary": false,
+      "body": "<?xml version='1.0' encoding='UTF-8'?>\n<sparql xmlns='http://www.w3.org/2005/sparql-results#'>\n\t<head>\n\t\t<variable name='s'/>\n\t\t<variable name='name'/>\n\t\t<variable name='hint'/>\n\t</head>\n\t<results>\n\t\t<result>\n\t\t\t<binding name='s'>\n\t\t\t\t<uri>http://vocab.getty.edu/ulan/500447664</uri>\n\t\t\t</binding>\n\t\t\t<binding name='name'>\n\t\t\t\t<literal>Palmer, Potter</literal>\n\t\t\t</binding>\n\t\t\t<binding name='hint'>\n\t\t\t\t<literal>American businessman, 1826-1902</literal>\n\t\t\t</binding>\n\t\t</result>\n\t</results>\n</sparql>\n",
+      "headers": {
+        "Access-Control-Allow-Origin": "*",
+        "Server": "GraphDB 6.2.7+sha.ab94d232, Forest 2.1.3, Sesame 2.7.8",
+        "Link": "<http://opendatacommons.org/licenses/by/1.0/>; rel=\"license\"",
+        "Content-Disposition": "attachment; filename=\"sparql.xml\"",
+        "Content-Type": "application/sparql-results+xml;charset=UTF-8",
+        "Content-Language": "en-US",
+        "Transfer-Encoding": "chunked",
+        "Date": "Wed, 27 May 2020 22:47:59 GMT"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/support/authoritex_case.ex
+++ b/test/support/authoritex_case.ex
@@ -70,17 +70,19 @@ defmodule Authoritex.TestCase do
         refute unquote(module).can_resolve?("info:fake/uri")
       end
 
-      test "code/0" do
-        assert unquote(module).code() == unquote(code)
-      end
+      describe "introspection" do
+        test "code/0" do
+          assert unquote(module).code() == unquote(code)
+        end
 
-      test "description/0" do
-        assert unquote(module).description() == unquote(description)
+        test "description/0" do
+          assert unquote(module).description() == unquote(description)
+        end
       end
 
       describe "fetch/1" do
         test "success" do
-          use_cassette "#{unquote(code)}_fetch_success" do
+          use_cassette "#{unquote(code)}_fetch_success", match_requests_on: [:query] do
             unquote(test_uris)
             |> Enum.each(fn uri ->
               assert unquote(module).fetch(uri) ==
@@ -96,7 +98,7 @@ defmodule Authoritex.TestCase do
         end
 
         test "failure" do
-          use_cassette "#{unquote(code)}_fetch_failure" do
+          use_cassette "#{unquote(code)}_fetch_failure", match_requests_on: [:query] do
             assert unquote(module).fetch(unquote(bad_uri)) == {:error, 404}
           end
         end


### PR DESCRIPTION
* Always use `match_requests_on: [:query]` with ExVCR
* Wrap the Getty subauthority test in an ExVCR cassette block
* Fix the intermittent `ulan_test.exs` compilation error