### PR TITLE
Add `Mock.init()` to avoid race conditions on setup

### DIFF
--- a/lib/authoritex/mock.ex
+++ b/lib/authoritex/mock.ex
@@ -7,6 +7,9 @@ defmodule Authoritex.Mock do
     # In test.exs:
     # config :authoritex, authorities: [Authoritex.Mock]
 
+    # In test_helper.exs:
+    # Authoritex.Mock.init()
+
     # In test case:
     iex> Authoritex.Mock.set_data([
       %{id: "mock:result1", label: "First Result", qualified_label: "First Result (1)", hint: "(1)"},
@@ -64,22 +67,21 @@ defmodule Authoritex.Mock do
     ArgumentError -> {:error, 500}
   end
 
+  def init do
+    :ets.new(__MODULE__, [:set, :named_table, :public])
+  rescue
+    ArgumentError -> __MODULE__
+  end
+
   def set_data(data) when is_list(data) do
-    :ets.insert(ets_table(), {Kernel.inspect(self()), data})
+    :ets.insert(Authoritex.Mock, {Kernel.inspect(self()), data})
     :ok
   end
 
   defp get_data do
-    case :ets.lookup(ets_table(), Kernel.inspect(self())) do
+    case :ets.lookup(Authoritex.Mock, Kernel.inspect(self())) do
       [] -> []
       [{_, data}] -> data
-    end
-  end
-
-  defp ets_table do
-    case :ets.whereis(__MODULE__) do
-      :undefined -> :ets.new(__MODULE__, [:set, :named_table, :public])
-      ref -> ref
     end
   end
 end

--- a/test/authoritex/mock_test.exs
+++ b/test/authoritex/mock_test.exs
@@ -3,6 +3,11 @@ defmodule Authoritex.MockTest do
 
   use ExUnit.Case, async: true
 
+  setup_all do
+    Mock.init()
+    :ok
+  end
+
   @data [
     %{
       id: "mock:result1",
@@ -35,6 +40,19 @@ defmodule Authoritex.MockTest do
 
   test "description/0" do
     assert Mock.description() == "Authoritex Mock Authority for Test Suites"
+  end
+
+  describe "thread safety" do
+    test "isolates data without argument errors" do
+      Enum.map(1..10, fn _ ->
+        Task.async(fn ->
+          assert :ok == Mock.set_data(@data)
+          assert {:ok, results} = Mock.search("everything")
+          assert length(results) == length(@data)
+        end)
+      end)
+      |> Enum.map(&Task.await(&1))
+    end
   end
 
   describe "fetch/1" do


### PR DESCRIPTION
This is how @bmquinn suggested handling initialization in the first place, but I talked him into trying to be clever and create the ETS table just-in-time, which caused the race condition we've been fighting with ever since.