### PR TITLE
Add support for missing_id_authority prefix in Mock.fetch/1

### DIFF
--- a/lib/authoritex/mock.ex
+++ b/lib/authoritex/mock.ex
@@ -20,6 +20,12 @@ defmodule Authoritex.Mock do
     iex> Authoritex.fetch("mock:result2")
     {:ok, %{id: "mock:result2", label: "Second Result", qualified_label: "Second Result (2)", hint: "(2)"}}
 
+    iex> Authoritex.fetch("missing_id_authority:anything")
+    {:error, 404}
+
+    iex> Authoritex.fetch("wrong")
+    {:error, :unknown_authority}
+
     iex> Authoritex.search("mock", "test")
     {:ok, [
             %{id: "mock:result1", label: "First Result", hint: "(1)"},
@@ -46,9 +52,13 @@ defmodule Authoritex.Mock do
   def can_resolve?(_id), do: true
 
   @impl Authoritex
+  def fetch("missing_id_authority:" <> _id) do
+    {:error, 404}
+  end
+
   def fetch(id) do
     case Enum.find(get_data(), &(&1.id == id)) do
-      nil -> {:error, 404}
+      nil -> {:error, :unknown_authority}
       record -> {:ok, record}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Authoritex.MixProject do
   use Mix.Project
 
-  @version "0.4.1"
+  @version "0.5.0"
   @url "https://github.com/nulib/authoritex"
 
   def project do

--- a/test/authoritex/mock_test.exs
+++ b/test/authoritex/mock_test.exs
@@ -72,8 +72,12 @@ defmodule Authoritex.MockTest do
                 }}
     end
 
-    test "failure" do
-      assert Mock.fetch("mock:result∞") == {:error, 404}
+    test "supports the missing_id_authority prefix to provide a 404 error response" do
+      assert Mock.fetch("missing_id_authority:123") == {:error, 404}
+    end
+
+    test "non-existent authorities provide an :unknown_authority error response" do
+      assert Mock.fetch("wrong") == {:error, :unknown_authority}
     end
   end
 


### PR DESCRIPTION
- Add support for missing_id_authority prefix in Mock.fetch/1 with slightly modified tests.
- Minor version bump to `0.5.0`