### PR TITLE
Rename default branch from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Authoritex
 
 [![Build](https://circleci.com/gh/nulib/authoritex.svg?style=svg)](https://circleci.com/gh/nulib/authoritex)
-[![Coverage](https://coveralls.io/repos/github/nulib/authoritex/badge.svg?branch=master)](https://coveralls.io/github/nulib/authoritex?branch=master)
+[![Coverage](https://coveralls.io/repos/github/nulib/authoritex/badge.svg?branch=main)](https://coveralls.io/github/nulib/authoritex?branch=main)
 [![Hex.pm](https://img.shields.io/hexpm/v/authoritex.svg)](https://hex.pm/packages/authoritex)
 
 An Elixir library for searching and fetching controlled vocabulary authority terms, inspired by


### PR DESCRIPTION
Developers need to run this locally:

```
git fetch --prune -a
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```