### PR TITLE
Don't match getty on bad uri with colon at start of string

### DIFF
--- a/lib/authoritex/getty/base.ex
+++ b/lib/authoritex/getty/base.ex
@@ -18,7 +18,9 @@ defmodule Authoritex.Getty.Base do
 
       @impl Authoritex
       def can_resolve?(unquote(http_uri) <> _id), do: true
-      def can_resolve?(unquote(prefix) <> _id), do: true
+      def can_resolve?(unquote(prefix) <> _ = id) do
+        unquote(prefix) != ":"
+      end
       def can_resolve?(_), do: false
 
       @impl Authoritex

--- a/test/authoritex_test.exs
+++ b/test/authoritex_test.exs
@@ -44,6 +44,11 @@ defmodule AuthoritexTest do
       assert Authoritex.fetch("info:fake/no-authority/12345") ==
                {:error, :unknown_authority}
     end
+
+    test "bad uri" do
+      assert Authoritex.fetch(":http://id.loc.gov/authorities/names/no2009131449") ==
+               {:error, :unknown_authority}
+    end
   end
 
   describe "search/2" do


### PR DESCRIPTION
- Getty was matching a uri with a colon at the start of the string. For example:  `:http://id.loc.gov/authorities/names/no2009091821` and then timing out trying to preform the `fetch`.
- This should produce an `{:error, :unknown_authority}` instead

Note: I debated dealing with this more globally then decided against it. But open to suggestions.